### PR TITLE
add package write permission to github token

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,8 @@ jobs:
   # https://github.com/edencehealth/workflows
   docker:
     uses: edencehealth/workflows/.github/workflows/dockerimage.yml@v1
+    permissions:
+      packages: write
     with:
       container_name: msda_switchbox_ui
       dockerhub_org: ''


### PR DESCRIPTION
This specifies the permissions that should be granted to the github token during a workflow run. This change enables the token to work in the context of uploading packages.